### PR TITLE
Finish the setter and getter for Astrometry.key

### DIFF
--- a/astroquery/astrometry_net/__init__.py
+++ b/astroquery/astrometry_net/__init__.py
@@ -38,6 +38,6 @@ conf = Conf()
 # Now import your public class
 # Should probably have the same name as your module
 
-from .core import Astrometry, AstrometryNetClass
+from .core import AstrometryNet, AstrometryNetClass
 
-__all__ = ['Astrometry', 'AstrometryNetClass']
+__all__ = ['AstrometryNet', 'AstrometryNetClass']

--- a/astroquery/astrometry_net/__init__.py
+++ b/astroquery/astrometry_net/__init__.py
@@ -38,6 +38,6 @@ conf = Conf()
 # Now import your public class
 # Should probably have the same name as your module
 
-from .core import Astrometry, AstrometryClass
+from .core import Astrometry, AstrometryNetClass
 
-__all__ = ['Astrometry', 'AstrometryClass']
+__all__ = ['Astrometry', 'AstrometryNetClass']

--- a/astroquery/astrometry_net/__init__.py
+++ b/astroquery/astrometry_net/__init__.py
@@ -13,6 +13,7 @@
 # Below is a common use case
 
 from astropy.config import ConfigurationItem
+from astropy import config as _config
 
 # Set the server mirrors to query
 SERVER = ConfigurationItem('server',
@@ -23,6 +24,16 @@ SERVER = ConfigurationItem('server',
 
 # Set the timeout for connecting to the server in seconds, here we set it to 30s
 TIMEOUT = ConfigurationItem('timeout', 30, 'default timeout for connecting to server')
+
+class Conf(_config.ConfigNamespace):
+    """ Configuration parameters for `astroquery.astrometry_net` """
+
+    key = _config.ConfigItem(
+        '',
+        "The Astrometry.net API key."
+        )
+
+conf = Conf()
 
 # Now import your public class
 # Should probably have the same name as your module

--- a/astroquery/astrometry_net/__init__.py
+++ b/astroquery/astrometry_net/__init__.py
@@ -28,7 +28,7 @@ TIMEOUT = ConfigurationItem('timeout', 30, 'default timeout for connecting to se
 class Conf(_config.ConfigNamespace):
     """ Configuration parameters for `astroquery.astrometry_net` """
 
-    key = _config.ConfigItem(
+    api_key = _config.ConfigItem(
         '',
         "The Astrometry.net API key."
         )

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -23,7 +23,7 @@ from . import conf
 
 
 # export all the public classes and methods
-__all__ = ['Astrometry', 'AstrometryClass']
+__all__ = ['Astrometry', 'AstrometryNetClass']
 
 # declare global variables and constants if any
 
@@ -31,7 +31,7 @@ __all__ = ['Astrometry', 'AstrometryClass']
 # should be decorated with the async_to_sync imported previously
 
 @async_to_sync
-class AstrometryClass(BaseQuery):
+class AstrometryNetClass(BaseQuery):
 
     """
     Not all the methods below are necessary but these cover most of the common cases, new methods may be added if necessary, follow the guidelines at <http://astroquery.readthedocs.org/en/latest/api.html>
@@ -444,17 +444,17 @@ class AstrometryClass(BaseQuery):
         print('id', result['subid'])
 
         time.sleep(5)
-        
+
         jobs = self.get_submit_status(subid, 30)
-        
+
         time.sleep(5)
-        
+
         wcs_fits = self.get_wcs_file(job_id, timeout)
-        
+
         return result
 
 # the default tool for users to interact with is an instance of the Class
-Astrometry = AstrometryClass()
+Astrometry = AstrometryNetClass()
 
 # once your class is done, tests should be written
 # See ./tests for examples on this

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -23,7 +23,7 @@ from . import conf
 
 
 # export all the public classes and methods
-__all__ = ['Astrometry', 'AstrometryNetClass']
+__all__ = ['AstrometryNet', 'AstrometryNetClass']
 
 # declare global variables and constants if any
 
@@ -454,7 +454,7 @@ class AstrometryNetClass(BaseQuery):
         return result
 
 # the default tool for users to interact with is an instance of the Class
-Astrometry = AstrometryNetClass()
+AstrometryNet = AstrometryNetClass()
 
 # once your class is done, tests should be written
 # See ./tests for examples on this

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -40,10 +40,6 @@ class AstrometryClass(BaseQuery):
     URL = SERVER()
     TIMEOUT = TIMEOUT()
 
-    def _get_stored_API_key(self):
-        """ Return the API key, raise KeyError if not cached on disk. """
-        raise KeyError
-
     @property
     def key(self):
         """ Return the Astrometry.net API key. """

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -63,12 +63,10 @@ class AstrometryClass(BaseQuery):
     def __init__(self):
         """ Load the cached API key, show a warning message if can't be found. """
 
-        try:
-            self._key = self._get_stored_API_key()
-        except KeyError:
-            log.warn("Astrometry.net API key not found")
+        if not conf.key:
+            log.warn("Astrometry.net API key not found in configuration file")
             log.warn("You need to register it with Astrometry.key = 'XXXXXXXX'")
-            self._key = None
+            log.warn("Alternatively, you may also edit the configuration file")
 
     def build_request(self, catalog, settings={}, x_colname='x', y_colname='y'):
         """

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -40,10 +40,6 @@ class AstrometryClass(BaseQuery):
     URL = SERVER()
     TIMEOUT = TIMEOUT()
 
-    def _store_API_key(self, value):
-        """ Cache the Astrometry.net API key on disk. """
-        pass
-
     def _get_stored_API_key(self):
         """ Return the API key, raise KeyError if not cached on disk. """
         raise KeyError

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -57,10 +57,8 @@ class AstrometryClass(BaseQuery):
 
     @key.setter
     def key(self, value):
-        """ Setter for the API key, cache it on disk. """
-
-        self._store_API_key(value)
-        self._key = value
+        """ Set the API key and update it in the configuration file. """
+        conf.key = value
 
     def __init__(self):
         """ Load the cached API key, show a warning message if can't be found. """

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -49,16 +49,16 @@ class AstrometryClass(BaseQuery):
 
     @key.setter
     def key(self, value):
-        """ Set the API key and update it in the configuration file. """
+        """ Temporarily set the API key. """
         conf.key = value
 
     def __init__(self):
-        """ Load the cached API key, show a warning message if can't be found. """
+        """ Show a warning message if the API key is not in the configuration file. """
 
         if not conf.key:
             log.warn("Astrometry.net API key not found in configuration file")
-            log.warn("You need to register it with Astrometry.key = 'XXXXXXXX'")
-            log.warn("Alternatively, you may also edit the configuration file")
+            log.warn("You need to manually edit the configuration file and add it")
+            log.warn("You may also register it for this session with Astrometry.key = 'XXXXXXXX'")
 
     def build_request(self, catalog, settings={}, x_colname='x', y_colname='y'):
         """

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -41,21 +41,21 @@ class AstrometryNetClass(BaseQuery):
     TIMEOUT = TIMEOUT()
 
     @property
-    def key(self):
+    def api_key(self):
         """ Return the Astrometry.net API key. """
-        if not conf.key:
+        if not conf.api_key:
             log.error("Astrometry.net API key not in configuration file")
-        return conf.key
+        return conf.api_key
 
-    @key.setter
-    def key(self, value):
+    @api_key.setter
+    def api_key(self, value):
         """ Temporarily set the API key. """
-        conf.key = value
+        conf.api_key = value
 
     def __init__(self):
         """ Show a warning message if the API key is not in the configuration file. """
 
-        if not conf.key:
+        if not conf.api_key:
             log.warn("Astrometry.net API key not found in configuration file")
             log.warn("You need to manually edit the configuration file and add it")
             log.warn("You may also register it for this session with Astrometry.key = 'XXXXXXXX'")

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -19,6 +19,7 @@ from ..utils import commons # has common functions required by most modules
 from ..utils import prepend_docstr_noreturns # automatically generate docs for similar functions
 from ..utils import async_to_sync # all class methods must be callable as static as well as instance methods.
 from . import SERVER, TIMEOUT # import configurable items declared in __init__.py
+from . import conf
 
 
 # export all the public classes and methods
@@ -49,11 +50,10 @@ class AstrometryClass(BaseQuery):
 
     @property
     def key(self):
-        """ Getter for the Astrometry.net API key. """
-
-        if self._key is None:
-            log.error("Astrometry.net API key not found")
-        return self._key
+        """ Return the Astrometry.net API key. """
+        if not conf.key:
+            log.error("Astrometry.net API key not in configuration file")
+        return conf.key
 
     @key.setter
     def key(self, value):

--- a/astroquery/astroquery.cfg
+++ b/astroquery/astroquery.cfg
@@ -199,4 +199,4 @@
 [astrometry_net]
 
 # The Astrometry.net API key
-key = None
+key =

--- a/astroquery/astroquery.cfg
+++ b/astroquery/astroquery.cfg
@@ -199,4 +199,4 @@
 [astrometry_net]
 
 # The Astrometry.net API key
-key =
+api_key =


### PR DESCRIPTION
The API key will have to be edited in the configuration file, since the ability to save configuration options was removed in Astropy 0.4. Assigning a value to the Astrometry.key property will only work for the current session.
